### PR TITLE
Add links to Minder rule types.

### DIFF
--- a/baseline.yaml
+++ b/baseline.yaml
@@ -128,6 +128,9 @@ criteria:
     control_mappings: # TODO
     scorecard_probe:
       - blocksForcePushOnBranches
+    minder_rules:
+      - name: osps-ac-03
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-ac-03.yaml
 
   - id: OSPS-AC-04
     maturity_level: 1
@@ -148,6 +151,9 @@ criteria:
     control_mappings: # TODO
     scorecard_probe:
       - blocksDeleteOnBranches
+    minder_rules:
+      - name: osps-ac-04
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-ac-04.yaml
 
   - id: OSPS-AC-05
     maturity_level: 2
@@ -390,6 +396,9 @@ criteria:
     security_insights_value: # TODO
     scorecard_probe:
       - # None yet
+    minder_rules:
+      - name: osps-do-01
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-do-01.yaml
 
   - id: OSPS-DO-02
     maturity_level: 1
@@ -412,6 +421,9 @@ criteria:
     security_insights_value: # TODO
     scorecard_probe:
       - # None, may not be suitable
+    minder_rules:
+      - name: osps-do-02
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-do-02.yaml
 
   - id: OSPS-DO-03
     maturity_level: 2
@@ -716,6 +728,9 @@ criteria:
     security_insights_value: # TODO
     scorecard_probe:
       - hasPermissiveLicense # Check this
+    minder_rules:
+      - name: osps-le-02
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-le-02.yaml
 
   - id: OSPS-LE-03
     maturity_level: 1
@@ -741,6 +756,9 @@ criteria:
     security_insights_value: # TODO
     scorecard_probe:
       - hasLicenseFile
+    minder_rules:
+      - name: osps-le-03
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-le-03.yaml
 
   - id: OSPS-LE-04
     maturity_level: 1
@@ -796,6 +814,9 @@ criteria:
       that would impact the repository URL.
     control_mappings: # TODO
     security_insights_value: # TODO
+    minder_rules:
+      - name: osps-qa-01
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-qa-01.yaml
 
   - id: OSPS-QA-02
     maturity_level: 1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,23 +17,36 @@ import (
 
 // Struct for representing each entry
 type Criterion struct {
-	ID                    string       `yaml:"id"`
-	MaturityLevel         int          `yaml:"maturity_level"`
-	Category              string       `yaml:"category"`
-	CriterionText         string       `yaml:"criterion"`
-	Rationale             string       `yaml:"rationale"`
-	Details               string       `yaml:"details"`
-	ControlMappings       string       `yaml:"control_mappings"`
-	SecurityInsightsValue string       `yaml:"security_insights_value"`
-	ScorecardProbe        []string     `yaml:"scorecard_probe"`
-	MinderRules           []MinderRule `yaml:"minder_rules"`
+	ID                    string   `yaml:"id"`
+	MaturityLevel         int      `yaml:"maturity_level"`
+	Category              string   `yaml:"category"`
+	CriterionText         string   `yaml:"criterion"`
+	Rationale             string   `yaml:"rationale"`
+	Details               string   `yaml:"details"`
+	ControlMappings       string   `yaml:"control_mappings"`
+	SecurityInsightsValue string   `yaml:"security_insights_value"`
+	ScorecardProbe        []string `yaml:"scorecard_probe"`
+	// MinderRules is a collection of references to Minder rules
+	// implementing the criterion.
+	MinderRules []MinderRule `yaml:"minder_rules"`
 }
 
 // MinderRules represents links to Minder rule type definitions along
 // with a configuration snippet.
 type MinderRule struct {
-	Name   string `yaml:"name"`
-	URL    string `yaml:"url"`
+	// Name is the name of the rule type or any other string to be
+	// shown as the link's anchor text.
+	Name string `yaml:"name"`
+	// URL is the destination of the link. It should preferably
+	// point to a rule type definition, but can also point to
+	// documentation.
+	URL string `yaml:"url"`
+	// Config is an example configuration snippet for the given
+	// rule. Rule configuration might span from simple strings to
+	// structured payloads, and depends on the rule type
+	// definition.
+	//
+	// This is currently rendered as YAML in the final template.
 	Config string `yaml:"config,omitempty"`
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,15 +17,24 @@ import (
 
 // Struct for representing each entry
 type Criterion struct {
-	ID                    string   `yaml:"id"`
-	MaturityLevel         int      `yaml:"maturity_level"`
-	Category              string   `yaml:"category"`
-	CriterionText         string   `yaml:"criterion"`
-	Rationale             string   `yaml:"rationale"`
-	Details               string   `yaml:"details"`
-	ControlMappings       string   `yaml:"control_mappings"`
-	SecurityInsightsValue string   `yaml:"security_insights_value"`
-	ScorecardProbe        []string `yaml:"scorecard_probe"`
+	ID                    string       `yaml:"id"`
+	MaturityLevel         int          `yaml:"maturity_level"`
+	Category              string       `yaml:"category"`
+	CriterionText         string       `yaml:"criterion"`
+	Rationale             string       `yaml:"rationale"`
+	Details               string       `yaml:"details"`
+	ControlMappings       string       `yaml:"control_mappings"`
+	SecurityInsightsValue string       `yaml:"security_insights_value"`
+	ScorecardProbe        []string     `yaml:"scorecard_probe"`
+	MinderRules           []MinderRule `yaml:"minder_rules"`
+}
+
+// MinderRules represents links to Minder rule type definitions along
+// with a configuration snippet.
+type MinderRule struct {
+	Name   string `yaml:"name"`
+	URL    string `yaml:"url"`
+	Config string `yaml:"config,omitempty"`
 }
 
 // Struct for holding the entire YAML structure

--- a/cmd/template.md
+++ b/cmd/template.md
@@ -87,6 +87,22 @@ _No security insights identified._
 _No scorecard probe identified._
 {{- end }}
 
+**Minder Rule(s):**
+{{ if .MinderRules }}
+{{- range .MinderRules }}
+- [{{ .Name }}]({{ .URL }})
+{{- if .Config }}
+
+```yaml
+{{ .Config }}
+```
+
+{{- end }}
+{{- end }}
+{{- else }}
+_No minder rule identified._
+{{- end }}
+
 ---
 
 {{- end }}


### PR DESCRIPTION
This change adds links to existing Minder rule types that implement Baseline checks.

Implementation is based on what was done for Scorecard probes, but definitions in `baseline.yaml` are a bit more complex since some Minder rules can be configured by the end user, and that bit of code lives in a Profile in Minder lingo.